### PR TITLE
fix: do not add PO-entries with empty message id

### DIFF
--- a/I18n/PO/Write.lean
+++ b/I18n/PO/Write.lean
@@ -111,7 +111,7 @@ namespace POFile
 A PO file is a series of po-entries, the first one should come from the header.
 -/
 def toString (f : POFile) : String :=
-  ("\n\n".intercalate (([f.header.toPOEntry] ++ f.entries.toList).map (fun e => s!"{e}"))) ++ "\n"
+  ("\n\n".intercalate (([f.header.toPOEntry] ++ f.entries.toList).map (s!"{·}"))) ++ "\n"
 
 instance : ToString POFile := ⟨POFile.toString⟩
 

--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -63,7 +63,7 @@ def _root_.String.markForTranslation [Monad m] [MonadEnv m] [MonadLog m] [AddMes
 
   let entry : POEntry := {
     msgId := key
-    ref := some [(env.mainModule.toString, none)]
+    ref := some [(env.mainModule.toString, none)] -- TODO: implement line number
     extrComment := extractedComment }
   modifyEnv (untranslatedKeysExt.addEntry · entry)
 
@@ -75,6 +75,11 @@ Returns the original string on failure.
 def _root_.String.translate [Monad m] [MonadEnv m] [MonadLog m] [AddMessageContext m]
     [MonadOptions m] (s : String) : m String := do
   let s := s.trimAscii.copy
+
+  -- validation: do not translate empty string
+  if s.length == 0 then
+    logInfo s!"Not adding empty translation key."
+    return ""
 
   s.markForTranslation
 

--- a/Test/Test_DE.lean
+++ b/Test/Test_DE.lean
@@ -18,7 +18,6 @@ def hello2 := t!"Test \n"
 #guard_msgs in
 #eval hello3
 
-
 def escapedString := t!"a \\` string \" with \\ escaped \\$ characters §, \
 some latex blocks $0$ and $$0 = 0$$, \
 and code blocks `a`, ``b`` and ```c with ` inside```"
@@ -27,5 +26,12 @@ info: "ein ` String \" mit \\ escapten $ Charaktern §, Latex-Blöcken $0$ und $
 -/
 #guard_msgs in
 #eval escapedString
+
+/-!
+Test: empty strings should not be added to the PO file as an empty `msgid` is reserved for the PO-Header
+and not allowed otherwise
+-/
+def empty := t!""
+def empty2 := t!" "
 
 #export_i18n


### PR DESCRIPTION
PO-msgid must not be empty as the empty one is reserved for the PO-header-entry.

Empty strings will thus not be translated and emit a `logInfo`

Part of: #25