### PR TITLE
Do not search for translations to source language

### DIFF
--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -84,16 +84,19 @@ def _root_.String.translate [Monad m] [MonadEnv m] [MonadLog m] [AddMessageConte
   s.markForTranslation
 
   let (key, codeBlocks) := s.extractCodeBlocks
-  match (← getTranslations)[key]? with
-  | none =>
-    -- Print a warning that the translation has not been found
-    let langConfig : LanguageState ← getLanguageState
-    logWarning s!"No translation ({langConfig.lang}) found for: {key}"
-    -- nevertheless, call `insertCodeBlocks` so that escape sequences are parsed properly
+  let langConfig : LanguageState ← getLanguageState
+  if langConfig.lang == langConfig.sourceLang then
     return key.insertCodeBlocks codeBlocks
-  | some tr =>
-    -- Insert the codeblocks from the original string into the translation.
-    return tr.insertCodeBlocks codeBlocks
+  else
+    match (← getTranslations)[key]? with
+    | none =>
+      -- Print a warning that the translation has not been found
+      logWarning s!"No translation ({langConfig.lang}) found for: {key}"
+      -- nevertheless, call `insertCodeBlocks` so that escape sequences are parsed properly
+      return key.insertCodeBlocks codeBlocks
+    | some tr =>
+      -- Insert the codeblocks from the original string into the translation.
+      return tr.insertCodeBlocks codeBlocks
 
 /--
 Translate an interpolated string by turning it into a normal string

--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -84,19 +84,17 @@ def _root_.String.translate [Monad m] [MonadEnv m] [MonadLog m] [AddMessageConte
   s.markForTranslation
 
   let (key, codeBlocks) := s.extractCodeBlocks
-  let langConfig : LanguageState ← getLanguageState
-  if langConfig.lang == langConfig.sourceLang then
-    return key.insertCodeBlocks codeBlocks
-  else
-    match (← getTranslations)[key]? with
-    | none =>
+  match (← getTranslations)[key]? with
+  | none =>
+    let langConfig : LanguageState ← getLanguageState
+    unless langConfig.lang == langConfig.sourceLang do
       -- Print a warning that the translation has not been found
       logWarning s!"No translation ({langConfig.lang}) found for: {key}"
-      -- nevertheless, call `insertCodeBlocks` so that escape sequences are parsed properly
-      return key.insertCodeBlocks codeBlocks
-    | some tr =>
-      -- Insert the codeblocks from the original string into the translation.
-      return tr.insertCodeBlocks codeBlocks
+    -- nevertheless, call `insertCodeBlocks` so that escape sequences are parsed properly
+    return key.insertCodeBlocks codeBlocks
+  | some tr =>
+    -- Insert the codeblocks from the original string into the translation.
+    return tr.insertCodeBlocks codeBlocks
 
 /--
 Translate an interpolated string by turning it into a normal string

--- a/Test/Test_DE.lean
+++ b/Test/Test_DE.lean
@@ -31,7 +31,15 @@ info: "ein ` String \" mit \\ escapten $ Charaktern §, Latex-Blöcken $0$ und $
 Test: empty strings should not be added to the PO file as an empty `msgid` is reserved for the PO-Header
 and not allowed otherwise
 -/
+
+/-- info: Not adding empty translation key. -/
+#guard_msgs in
 def empty := t!""
+
+/-- info: Not adding empty translation key. -/
+#guard_msgs in
 def empty2 := t!" "
 
+/-- info: i18n: file created at -/
+#guard_msgs (substring := true) in
 #export_i18n

--- a/Test/Test_EN.lean
+++ b/Test/Test_EN.lean
@@ -1,38 +1,35 @@
 import I18n
 
+/-- warning: Translation file not found -/
+#guard_msgs (substring := true) in
 set_language en
 
-/-- warning: No translation (en) found for: hello world: §0 is §1 and §2 -/
 #guard_msgs in
 def hello := t!"hello world: `a` is `b` and ```\nTest\n```\n"
-
-/-- warning: No translation (en) found for: hello world -/
-#guard_msgs in
-def hello3 := t!"hello world"
-
-/-- warning: No translation (en) found for: Test -/
-#guard_msgs in
-def hello2 := t!"Test \n"
 
 /-- info: "hello world: `a` is `b` and ```\nTest\n```" -/
 #guard_msgs in
 #eval hello
 
+#guard_msgs in
+def hello2 := t!"Test \n"
+
 /-- info: "Test" -/
 #guard_msgs in
 #eval hello2
+
+#guard_msgs in
+def hello3 := t!"hello world"
 
 /-- info: "hello world" -/
 #guard_msgs in
 #eval hello3
 
-/--
-warning: No translation (en) found for: a ` string " with \\ escaped $ characters \§, some latex blocks §0 and §1, and code blocks §2, §3 and §4
--/
 #guard_msgs in
 def escapedString := t!"a \\` string \" with \\ escaped \\$ characters §, \
 some latex blocks $0$ and $$0 = 0$$, \
 and code blocks `a`, ``b`` and ```c with ` inside```"
+
 /--
 info: "a ` string \" with \\ escaped $ characters §, some latex blocks $0$ and $$0 = 0$$, and code blocks `a`, ``b`` and ```c with ` inside```"
 -/
@@ -40,4 +37,6 @@ info: "a ` string \" with \\ escaped $ characters §, some latex blocks $0$ and 
 #eval escapedString
 
 
+/-- info: i18n: file created at -/
+#guard_msgs (substring := true) in
 #export_i18n


### PR DESCRIPTION
Reintroduces a check if the target language and source language are the same in the `translate` function.

Fixes #29.