### PR TITLE
fix: drop message about empty translation

### DIFF
--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -63,6 +63,11 @@ Add a string to the set of untranslated strings
 -/
 meta def _root_.String.markForTranslation [Monad m] [MonadEnv m] [MonadLog m] [AddMessageContext m]
     [MonadOptions m] (s : String) : m Unit := do
+
+  -- validation: do not translate empty string
+  if s.length == 0 then
+    return
+
   let env ← getEnv
 
   let (key, codeBlocks) := s.extractCodeBlocks
@@ -88,7 +93,6 @@ meta def _root_.String.translate [Monad m] [MonadEnv m] [MonadLog m] [AddMessage
 
   -- validation: do not translate empty string
   if s.length == 0 then
-    logInfo s!"Not adding empty translation key."
     return ""
 
   s.markForTranslation

--- a/Test/Test_DE.lean
+++ b/Test/Test_DE.lean
@@ -34,11 +34,9 @@ Test: empty strings should not be added to the PO file as an empty `msgid` is re
 and not allowed otherwise
 -/
 
-/-- info: Not adding empty translation key. -/
 #guard_msgs in
 def empty := t!""
 
-/-- info: Not adding empty translation key. -/
 #guard_msgs in
 def empty2 := t!" "
 


### PR DESCRIPTION
This info is rather useless and annoying