### PR TITLE
feat: replaced dotted module paths to slashes in POT refs

### DIFF
--- a/I18n/PO/Write.lean
+++ b/I18n/PO/Write.lean
@@ -16,8 +16,9 @@ namespace I18n
 namespace POEntry
 
 /-- A file name containing spaces is wrapped in U+2068 and U+2069. -/
-def escapeRef (s : String) : String := if
-  s.contains ' ' then s!"⁨{s}⁩" else s
+def escapeRef (s : String) : String :=
+  let s := s.replace "." "/"
+  if s.contains ' ' then s!"⁨{s}⁩" else s
 -- TODO: remove these characters when parsing a file!
 
 -- TODO: escape '"' everywhere

--- a/I18n/PO/Write.lean
+++ b/I18n/PO/Write.lean
@@ -16,9 +16,8 @@ namespace I18n
 namespace POEntry
 
 /-- A file name containing spaces is wrapped in U+2068 and U+2069. -/
-def escapeRef (s : String) : String :=
-  let s := s.replace "." "/"
-  if s.contains ' ' then s!"⁨{s}⁩" else s
+def escapeRef (s : String) : String := if
+  s.contains ' ' then s!"⁨{s}⁩" else s
 -- TODO: remove these characters when parsing a file!
 
 -- TODO: escape '"' everywhere

--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -59,6 +59,16 @@ elab "set_language" lang:ident : command => do
   Elab.Command.liftCoreM <| loadTranslations
 
 /--
+Turns a module name `Package.Module.Name` into `Package/Module/Name.lean`.
+Does not check if the resulting file exists.
+
+Note: one could use `FilePath` for this. However, we want consistent separators across different
+OS and it seems in the `FilePath`-API one cannot manually specify the separator
+ -/
+private meta def toSourceFilePath (mod : Name) : String :=
+  mod.toString.replace "." "/" ++ ".lean"
+
+/--
 Add a string to the set of untranslated strings
 -/
 meta def _root_.String.markForTranslation [Monad m] [MonadEnv m] [MonadLog m] [AddMessageContext m]
@@ -78,7 +88,7 @@ meta def _root_.String.markForTranslation [Monad m] [MonadEnv m] [MonadLog m] [A
 
   let entry : POEntry := {
     msgId := key
-    ref := some [(env.mainModule.toString, none)] -- TODO: implement line number
+    ref := some [(toSourceFilePath env.mainModule, none)] -- TODO: implement line number
     extrComment := extractedComment }
   modifyEnv (untranslatedKeysExt.addEntry · entry)
 


### PR DESCRIPTION
Generated `Game.pot` in Robo with no issues and doesn't break anything. No changes needed in `Translate.lean` since dots get replaced with / when writing the pot file.