### PR TITLE
feat: filter empty strings on export

### DIFF
--- a/.i18n/de/i18n.po
+++ b/.i18n/de/i18n.po
@@ -16,6 +16,15 @@ msgstr "Hallo Welt"
 msgid "Test"
 msgstr "Test"
 
+#: Test.Test
+#, lean-empty, other-flag1
+msgid "deliberately empty"
+msgstr ""
+
+#: Test.Test
+msgid "empty and missing"
+msgstr ""
+
 #. §0: `a`
 #. §1: `b`
 #. §2: ```

--- a/I18n/Json/Write.lean
+++ b/I18n/Json/Write.lean
@@ -1,7 +1,6 @@
 module
 
 public import I18n.EnvExtension
--- import DateTime
 
 public section
 
@@ -13,10 +12,17 @@ Compatible with `i18next`.
 open Lean System
 namespace I18n
 
+/--
+Convert PO-File to Json. Filters out all empty translations, unless they are
+marked with the flag `lean-empty`.
+-/
 def POFile.toJson (poFile : POFile) : Json :=
-  Json.mkObj <| poFile.entries.map (fun entry => (entry.msgId, Json.str entry.msgStr)) |>.toList
-
-open Elab.Command in
+  Json.mkObj <| Array.toList <| poFile.entries.filterMap fun entry =>
+    let flags := entry.flags.getD ∅
+    if flags.contains "lean-empty" || !entry.msgStr.isEmpty then
+      some (entry.msgId, Json.str entry.msgStr)
+    else
+      none
 
 def POFile.saveAsJson (poFile : POFile) (path : FilePath) : IO Unit := do
   -- TODO: add overwrite-check

--- a/I18n/PO/Definition.lean
+++ b/I18n/PO/Definition.lean
@@ -13,7 +13,9 @@ namespace I18n
 Specification:
 https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
 
-Additionally, we use one new flag: `lean-format` to mark interpolated strings.
+Additionally, we use some custom flags:
+- `lean-empty` to mark strings which are deliberately empty
+- `lean-format` to mark interpolated strings -- TODO: is this used??
 -/
 
 /--

--- a/I18n/Template.lean
+++ b/I18n/Template.lean
@@ -101,7 +101,6 @@ meta def createTemplate : CommandElabM Unit := do
   let path ← createTemplateAux mergedKeys
   logInfo s!"i18n: file created at {path}"
 
-
 /-- Create a i18n-template-file now! -/
 elab "#export_i18n" : command => do
   createTemplate

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ in the [GNU gettext manual](https://www.gnu.org/software/gettext/manual/html_nod
 If your third-party software can not import a PO-file or produces a PO-file which can't be parsed (correctly) in Lean,
 please create a bug report here with a sample PO-file!
 
+### Custom Flags
+
+The following custom flags are being used:
+
+- `lean-empty`: tells the PO-to-Json export not to filter out this empty translation
+
 ## Json Files
 
 Currently the recommended workflow to retrieve i18next-compatible JSON files is the following:


### PR DESCRIPTION
- Introduces a custom flag `lean-empty`.
- Json export filters out empty translations unless they are marked with this flag.

This is the first part of #37 and allows lean4game to distinguish between deliberately empty translations and missing ones. lean4game will need a follow-up setting the corresponding `i18next`-option.