### PR TITLE
feat: Add source-order POT sorting with duplicate warnings

### DIFF
--- a/I18n/Cli.lean
+++ b/I18n/Cli.lean
@@ -23,9 +23,12 @@ public meta unsafe def i18nCLI (args : Cli.Parsed) : IO UInt32 := do
     initSearchPath (← findSysroot)
     unsafe Lean.enableInitializersExecution
     try I18n.withImportModules #[module] {} (trustLevel := 1024) fun env => do
-      -- same as `createTemplate` but we're not in `CommandElabM`, but have the `env` explicitely
       let keys := untranslatedKeysExt.getState env
-      let path ← createTemplateAux keys
+      let langConfig ← readLanguageConfig
+      let (sortedKeys, warnings) := prepareTemplateEntries keys langConfig.sortByFile
+      for warning in warnings do
+        IO.eprintln warning.toString
+      let path ← createTemplateAux sortedKeys
       IO.println s!"i18n: file created at {path}"
     catch err =>
       throw <| IO.userError <| s!"{err}\n" ++

--- a/I18n/EnvExtension.lean
+++ b/I18n/EnvExtension.lean
@@ -23,6 +23,12 @@ open Lean
 
 namespace I18n
 
+-- comment
+register_option i18n.sortByFile : Bool := {
+  defValue := true
+  descr    := "sort POT entries by file order and occurrence within file, and warn about duplicate msgids"
+}
+
 /--
 Contains all extraced, yet untranslated strings.
 `t!"…"`, `tm!"…"`, and `String.translate` add the untranslated strings here.

--- a/I18n/EnvExtension.lean
+++ b/I18n/EnvExtension.lean
@@ -23,9 +23,8 @@ open Lean
 
 namespace I18n
 
--- comment
 register_option i18n.sortByFile : Bool := {
-  defValue := true
+  defValue := false
   descr    := "sort POT entries by file order and occurrence within file, and warn about duplicate msgids"
 }
 
@@ -69,6 +68,9 @@ structure LanguageState where
   /-- Use i18next-compatible json files. Not that they contain strictly less
   information than PO files. -/
   useJson := false
+  /-- Sort template entries by their first occurrence in the source files.
+  If this is false, template entries are sorted by `msgid`. -/
+  sortByFile := false
 
 instance : Inhabited LanguageState := ⟨{}⟩ -- all fields have default options.
 
@@ -103,7 +105,8 @@ def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := d
       "  \"sourceLang\": \"en\",\n" ++
       -- s!"  \"lang\": \"{lang}\",\n" ++
       "  \"translationContactEmail\": \"\",\n" ++
-      "  \"useJson\": false\n" ++
+      "  \"useJson\": false,\n" ++
+      "  \"sortByFile\": false\n" ++
       "}\n"
     return {}
   else
@@ -130,6 +133,11 @@ def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := d
           | .ok mm => mm
           | .error _ => panic! s!"in {file}, key `useJson`: not a boolean"
         | .error _ => false -- panic! s!"{file} does not contain key `useJson`!"
+      let sortByFile := match res.getObjVal? "sortByFile" with
+        | .ok m => match m.getBool? with
+          | .ok mm => mm
+          | .error _ => panic! s!"in {file}, key `sortByFile`: not a boolean"
+        | .error _ => false
 
       let lang := match lang? with
       | some l => l
@@ -139,7 +147,8 @@ def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := d
         lang := lang
         sourceLang := sourceLang
         translationContactEmail := email
-        useJson := useJson }
+        useJson := useJson
+        sortByFile := sortByFile }
     | .error err =>
       panic! s!"Failed to read {file}! ({err})"
 

--- a/I18n/Template.lean
+++ b/I18n/Template.lean
@@ -52,6 +52,54 @@ meta def mergeMetaDataList (a : List POEntry) : POEntry := match a with
 
 end POEntry
 
+/-- A duplicate `msgid` found while preserving source-file order. -/
+structure DuplicateMsgIdWarning where
+  msgId : String
+  refs : List String
+  deriving Inhabited
+
+namespace DuplicateMsgIdWarning
+
+meta def toString (warning : DuplicateMsgIdWarning) : String :=
+  s!"i18n: duplicate msgid '{warning.msgId}' found in files: {", ".intercalate warning.refs}"
+
+meta def toMessageData (warning : DuplicateMsgIdWarning) : MessageData :=
+  m!"{warning.toString}"
+
+end DuplicateMsgIdWarning
+
+/--
+By default, entries are sorted by `msgid` and duplicate keys are merged silently.
+With `sortByFile`, entries keep their first source occurrence.
+Duplicate `msgid`s warn because later uses disappear into the first merged entry.
+-/
+meta def prepareTemplateEntries (keys : Array POEntry) (sortByFile : Bool) :
+    Array POEntry × Array DuplicateMsgIdWarning := Id.run do
+  let groupedEntries : Std.HashMap String (Array POEntry) := keys.groupByKey (·.msgId)
+
+  if sortByFile then
+    let mut result := #[]
+    let mut warnings := #[]
+    let mut seen : Std.HashMap String Unit := {}
+
+    for entry in keys do
+      let id := entry.msgId
+      unless seen.contains id do
+        seen := seen.insert id ()
+        let entries := (groupedEntries[id]?).getD #[]
+
+        if entries.size > 1 then
+          let refs := entries.flatMap (fun e => ((e.ref.getD []).map (·.1)).toArray)
+          let uniqueRefs := refs.toList.eraseDups
+          warnings := warnings.push { msgId := id, refs := uniqueRefs }
+
+        result := result.push (POEntry.mergeMetaDataList entries.toList)
+    return (result, warnings)
+  else
+    let mergedKeys : Array POEntry := groupedEntries.toArray.map (fun (_msgId, entries) =>
+      POEntry.mergeMetaDataList entries.toList)
+    return (mergedKeys.qsort (fun e₁ e₂ => e₁.msgId < e₂.msgId), #[])
+
 /--
 Write all collected untranslated strings into a template file.
 
@@ -92,40 +140,17 @@ Write all collected untranslated strings into a template file.
 -/
 meta def createTemplate : CommandElabM Unit := do
   let keys := untranslatedKeysExt.getState (← getEnv)
+  let langConfig ← readLanguageConfig
+  let opts ← getOptions
+  let sortByFile := langConfig.sortByFile || opts.getBool `i18n.sortByFile false
+  let (sortedKeys, warnings) := prepareTemplateEntries keys sortByFile
 
-  -- there might be multiple keys with identical msgId, which we need to merge
-  -- group entries by msgid to easily find duplicates and merge data
-  let groupedEntries : Std.HashMap String (Array POEntry) := keys.groupByKey (·.msgId)
-
-  let sortByFile := (← getOptions).getBool `i18n.sortByFile true
-
-  let sortedKeys ← if sortByFile then
-    let mut result := #[]
-    let mut seen : Std.HashMap String Unit := {}
-
-    for entry in keys do
-      let id := entry.msgId
-      unless seen.contains id do
-        seen := seen.insert id ()
-        let entries := (groupedEntries[id]?).getD #[]
-
-        -- If this ID appears multiple times while building, give a warning
-        if entries.size > 1 then
-          let refs := entries.flatMap (fun e => ((e.ref.getD []).map (·.1)).toArray)
-          --Clean up output by removing duplicate file strings
-          let uniqueRefs := refs.toList.eraseDups
-          logWarning m!"i18n: duplicate msgid '{id}' found in files: {", ".intercalate uniqueRefs}"
-
-        result := result.push (POEntry.mergeMetaDataList entries.toList)
-    pure result
-  else
-    -- Default branch: sorted alphabetically at the end
-    let mergedKeys : Array POEntry := groupedEntries.toArray.map (fun (_msgId, entries) =>
-      POEntry.mergeMetaDataList entries.toList)
-    pure <| mergedKeys.qsort (fun e₁ e₂ => e₁.msgId < e₂.msgId)
+  for warning in warnings do
+    logWarning warning.toMessageData
 
   let path ← createTemplateAux sortedKeys
   logInfo s!"i18n: file created at {path}"
 
-  elab "#export_i18n" : command => do
+open Elab.Command in
+elab "#export_i18n" : command => do
   createTemplate

--- a/I18n/Template.lean
+++ b/I18n/Template.lean
@@ -94,13 +94,38 @@ meta def createTemplate : CommandElabM Unit := do
   let keys := untranslatedKeysExt.getState (← getEnv)
 
   -- there might be multiple keys with identical msgId, which we need to merge
+  -- group entries by msgid to easily find duplicates and merge data
   let groupedEntries : Std.HashMap String (Array POEntry) := keys.groupByKey (·.msgId)
-  let mergedKeys : Array POEntry := groupedEntries.toArray.map (fun (_msgId, entries) =>
-    POEntry.mergeMetaDataList entries.toList)
 
-  let path ← createTemplateAux mergedKeys
+  let sortByFile := (← getOptions).getBool `i18n.sortByFile true
+
+  let sortedKeys ← if sortByFile then
+    let mut result := #[]
+    let mut seen : Std.HashMap String Unit := {}
+
+    for entry in keys do
+      let id := entry.msgId
+      unless seen.contains id do
+        seen := seen.insert id ()
+        let entries := (groupedEntries[id]?).getD #[]
+
+        -- If this ID appears multiple times while building, give a warning
+        if entries.size > 1 then
+          let refs := entries.flatMap (fun e => ((e.ref.getD []).map (·.1)).toArray)
+          --Clean up output by removing duplicate file strings
+          let uniqueRefs := refs.toList.eraseDups
+          logWarning m!"i18n: duplicate msgid '{id}' found in files: {", ".intercalate uniqueRefs}"
+
+        result := result.push (POEntry.mergeMetaDataList entries.toList)
+    pure result
+  else
+    -- Default branch: sorted alphabetically at the end
+    let mergedKeys : Array POEntry := groupedEntries.toArray.map (fun (_msgId, entries) =>
+      POEntry.mergeMetaDataList entries.toList)
+    pure <| mergedKeys.qsort (fun e₁ e₂ => e₁.msgId < e₂.msgId)
+
+  let path ← createTemplateAux sortedKeys
   logInfo s!"i18n: file created at {path}"
 
-/-- Create a i18n-template-file now! -/
-elab "#export_i18n" : command => do
+  elab "#export_i18n" : command => do
   createTemplate

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Any of these options will create a file `.i18n/en/[YourProject].pot` which you c
 translate using any a suitable editor like "Poedit" (these editors also help you merging a modified `.pot` into an existing translation).
 The translated files should be saved as `.i18n/[lang]/[YourProject].po`.
 
+Template entries are sorted by `msgid` by default. This keeps generated template files
+stable and silently merges duplicate `msgid`s. If you prefer entries in source-file order,
+set `"sortByFile": true` in `.i18n/config.json`. With this option enabled, duplicate
+`msgid`s produce warnings because they can make source-order sorting ambiguous. For a
+single `#export_i18n` invocation, you can enable source-file sorting locally when
+the config leaves it disabled:
+
+```lean
+set_option i18n.sortByFile true
+#export_i18n
+```
+
 Once you have a translation present, you can use `set_language` to translate everything
 in the current document: e.g. set `set_language fr` at the top of your lean document and you
 should get your French translation of strings printed.


### PR DESCRIPTION
This addresses #23 and #26.

By default:
- entries are sorted by `msgid`
- duplicate `msgid`s are merged silently

Robo, `.i18n/config.json` now supports:

`"sortByFile": true`

With this enabled:
- entries are ordered by their first occurrence in the source files
- duplicate msgids produce warnings