### PR TITLE
Fix/poedit code occurrences

### DIFF
--- a/I18n/PO/Definition.lean
+++ b/I18n/PO/Definition.lean
@@ -76,6 +76,8 @@ structure POHeaderEntry where
   contentType : String := "text/plain; charset=UTF-8"
   contentTransferEncoding : String := "8bit"
   pluralForms : Option String := none
+  poeditBasepath : Option String := some "../.."
+  poeditSearchPath : Option String := some "."
 
 /-- A PO-file is a document containing translations of strings into a different language. -/
 structure POFile where

--- a/I18n/PO/Write.lean
+++ b/I18n/PO/Write.lean
@@ -101,6 +101,8 @@ def toPOHeaderEntry (header : POEntry): POHeaderEntry := Id.run do
     contentType := find pairs "Content-Type"
     contentTransferEncoding := find pairs "Content-Transfer-Encoding"
     pluralForms := findOpt pairs "Plural-Forms"
+    poeditBasepath := findOpt pairs "X-Poedit-Basepath"
+    poeditSearchPath := findOpt pairs "X-Poedit-SearchPath-0"
   }
 where
   find (pairs: List (String × String)) (key : String) :=
@@ -130,6 +132,10 @@ def toPOEntry (header : POHeaderEntry): POEntry := Id.run do
   msgStr := msgStr.append s!"\nContent-Transfer-Encoding: {header.contentTransferEncoding}"
   if let some pluralForms := header.pluralForms then
     msgStr := msgStr.append s!"\nPlural-Forms: {pluralForms}"
+  if let some poeditBasepath := header.poeditBasepath then
+    msgStr := msgStr.append s!"\nX-Poedit-Basepath: {poeditBasepath}"
+  if let some poeditSearchPath := header.poeditSearchPath then
+    msgStr := msgStr.append s!"\nX-Poedit-SearchPath-0: {poeditSearchPath}"
   return {msgId := "", msgStr := msgStr}
 
 end POHeaderEntry

--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -94,9 +94,10 @@ meta def _root_.String.markForTranslation [Monad m] [MonadEnv m] [MonadLog m] [A
   | 0 => none
   | _ => some <| codeBlocks.zipIdx.foldl (init := "") fun acc (block, n) => acc ++ s!"§{n}: {block}\n"
 
+  let pos ← getRefPosition
   let entry : POEntry := {
     msgId := key
-    ref := some [(toSourceFilePath env.mainModule, none)] -- TODO: implement line number
+    ref := some [(toSourceFilePath env.mainModule, some pos.line)]
     extrComment := extractedComment }
   modifyEnv (untranslatedKeysExt.addEntry · entry)
 

--- a/Test/POHeader.lean
+++ b/Test/POHeader.lean
@@ -12,7 +12,9 @@ info: { projectIdVersion := "i18n v4.22.0",
   language := "de",
   contentType := "text/plain; charset=UTF-8",
   contentTransferEncoding := "8bit",
-  pluralForms := none }
+  pluralForms := none,
+  poeditBasepath := none,
+  poeditSearchPath := none }
 -/
 #guard_msgs in
 #eval POEntry.toPOHeaderEntry {


### PR DESCRIPTION
The generated PO files didn’t tell Poedit where the project root was. Because the translation files are inside `.i18n/(language)/`, Poedit couldn’t find source files such as `Game/Levels/...lean`.
Poedit now has the correct search paths + each ref includes its source line number.