### PR TITLE
fix: do not use module system in CLI

### DIFF
--- a/I18n/Cli.lean
+++ b/I18n/Cli.lean
@@ -37,6 +37,8 @@ public meta unsafe def i18nCLI (args : Cli.Parsed) : IO UInt32 := do
 
   if args.hasFlag "export-json" then
     let files ← findFilesWithExtension ".i18n" "po"
+    if files.isEmpty then
+      IO.println "i18n: not found any PO files."
 
     for file in files do
       let outFile := file.withExtension "json"

--- a/Main.lean
+++ b/Main.lean
@@ -1,12 +1,10 @@
-module
-
-public meta import Cli.Basic
-public import I18n.Cli
+import Cli.Basic
+import I18n.Cli
 
 open Cli
 
 /-- Setting up command line options and help text for `lake exe graph`. -/
-meta unsafe def i18n : Cmd := `[Cli|
+unsafe def i18n : Cmd := `[Cli|
   i18n VIA I18n.i18nCLI; ["0.1.0"]
   "I18n CLI
   Tool for internationalisation of Lean projects.
@@ -18,5 +16,5 @@ meta unsafe def i18n : Cmd := `[Cli|
 ]
 
 /-- `lake exe i18n` -/
-public meta unsafe def main (args : List String) : IO UInt32 :=
+unsafe def main (args : List String) : IO UInt32 :=
   i18n.validate args


### PR DESCRIPTION
This is a workaround for leanprover/lean4-cli#89

Without it `lean exe i18n` is just silent not doing anything on Lean v4.30.0+

Closes: #48