### PR TITLE
Support translations in dependent packages

### DIFF
--- a/I18n.lean
+++ b/I18n.lean
@@ -1,5 +1,6 @@
 module
 
+public import I18n.Project
 public import I18n.EnvExtension
 public import I18n.InterpolatedStr
 public import I18n.Json

--- a/I18n/EnvExtension.lean
+++ b/I18n/EnvExtension.lean
@@ -3,6 +3,7 @@ module
 public import Lean
 public import I18n.PO.Definition
 public import I18n.Language
+public import I18n.Project
 
 public section
 
@@ -38,6 +39,24 @@ meta initialize untranslatedKeysExt : SimplePersistentEnvExtension POEntry (Arra
     asyncMode := .sync
     addEntryFn := Array.push
     addImportedFn := Array.flatMap id }
+
+/-- Return untranslated entries owned by one Lake package. -/
+meta def getUntranslatedKeysForPackage (env : Environment) (packageId : PkgId) : Array POEntry :=
+    Id.run do
+  let mut keys := #[]
+
+  for moduleName in env.header.moduleNames do
+    if let some idx := env.getModuleIdx? moduleName then
+      if env.getModulePackageByIdx? idx == some packageId then
+        keys := keys ++ untranslatedKeysExt.getModuleEntries env idx
+
+  let includeLocal := match env.getModulePackage? with
+    | some currentPackage => currentPackage == packageId
+    | none => true
+  if includeLocal then
+    keys := keys ++ (untranslatedKeysExt.getEntries env).toArray
+
+  return keys
 
 /--
 Debugging only. Prints the current state of the environment extension storing all untranslated keys.
@@ -95,20 +114,24 @@ package. Might be replaced if setting custom options in the lakefile ever gets i
 Note: The target language is not in the config file as in the current setup this is
 provided through the `Language` command.
 -/
-def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := do
-  let projectDir ← IO.currentDir
+def readLanguageConfigAt (projectDir : System.FilePath) (lang? : Option Language := none)
+    (createIfMissing := true) : IO LanguageState := do
   let path := projectDir / ".i18n"
-  IO.FS.createDirAll path
   let file := path / "config.json"
   if ¬ (← System.FilePath.pathExists file) then
-    IO.FS.writeFile file <| "{\n" ++
-      "  \"sourceLang\": \"en\",\n" ++
-      -- s!"  \"lang\": \"{lang}\",\n" ++
-      "  \"translationContactEmail\": \"\",\n" ++
-      "  \"useJson\": false,\n" ++
-      "  \"sortByFile\": false\n" ++
-      "}\n"
-    return {}
+    if createIfMissing then
+      IO.FS.createDirAll path
+      IO.FS.writeFile file <| "{\n" ++
+        "  \"sourceLang\": \"en\",\n" ++
+        -- s!"  \"lang\": \"{lang}\",\n" ++
+        "  \"translationContactEmail\": \"\",\n" ++
+        "  \"useJson\": false,\n" ++
+        "  \"sortByFile\": false\n" ++
+        "}\n"
+    let state : LanguageState := {}
+    return match lang? with
+      | some lang => {state with lang}
+      | none => state
   else
     let content ← IO.FS.readFile file
     match Json.parse content with
@@ -152,6 +175,9 @@ def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := d
     | .error err =>
       panic! s!"Failed to read {file}! ({err})"
 
+def readLanguageConfig (lang? : Option Language := none) : IO LanguageState := do
+  readLanguageConfigAt (← IO.currentDir) lang?
+
 /--
 This extension holds the loaded translations `sourceLang` to `lang`.
 It is up to the developer to keep it in sync with the `languageExt`.
@@ -161,7 +187,11 @@ initialize translationExt : SimplePersistentEnvExtension (String × String) (Std
       name := `i18n_translations
       asyncMode := .sync
       addEntryFn := fun hm (x : String × String) => hm.insert x.1 x.2
-      addImportedFn := fun arr => Std.HashMap.ofList (arr.flatMap id).toList }
+      /-
+      Translation maps are compile-time inputs for the current module. Importing them allows an unrelated
+      dependency translation with the same msgid to leak into this package.
+      -/
+      addImportedFn := fun _ => {} }
 
 /--
 Get the translations from the environment. It is a `HashMap String String`

--- a/I18n/Project.lean
+++ b/I18n/Project.lean
@@ -1,0 +1,62 @@
+module
+
+public import Lean.Compiler.ModPkgExt
+public import Lake.Load.Manifest
+
+public section
+
+open Lean System
+
+namespace I18n
+
+/-- Translations that are currently being processed. -/
+structure ProjectContext where
+  /-- Package identifier -/
+  id : PkgId
+  /-- Name used for PO and JSON filenames -/
+  name : Name
+  dir : FilePath
+  /-- answears: is this a root package? -/
+  isRoot : Bool
+deriving Repr
+
+private def packageId (name : Name) : PkgId :=
+  name.toString (escape := false)
+
+/-- Read the active workspace manifest and return its root package -/
+def getRootProjectContext : IO ProjectContext := do
+  let dir ← IO.currentDir
+  match ← Lake.Manifest.load? (dir / "lake-manifest.json") with
+  | none =>
+    return { id := "project", name := `project, dir, isRoot := true }
+  | some manifest =>
+    return { id := packageId manifest.name, name := manifest.name, dir, isRoot := true }
+
+/-- Resolve a Lake package identifier to its package directory in the active workspace -/
+def getProjectContextForPackage (id : PkgId) : IO ProjectContext := do
+  let rootDir ← IO.currentDir
+  let some manifest ← Lake.Manifest.load? (rootDir / "lake-manifest.json")
+    | throw <| IO.userError "i18n: lake manifest could not be read"
+
+  if packageId manifest.name == id then
+    return { id, name := manifest.name, dir := rootDir, isRoot := true }
+
+  let some entry := manifest.packages.find? (packageId ·.name == id)
+    | throw <| IO.userError s!"i18n: package '{id}' is missing from lake-manifest.json"
+
+  let dir := match entry.src with
+    | .path dir => rootDir / dir
+    | .git _url _rev _inputRev? subDir? =>
+      let packagesDir := manifest.packagesDir?.getD (manifest.lakeDir / "packages")
+      let repositoryDir := rootDir / packagesDir / entry.name.toString (escape := false)
+      match subDir? with
+      | some subDir => repositoryDir / subDir
+      | none => repositoryDir
+
+  return { id, name := entry.name, dir, isRoot := false }
+
+/-- Resolve the package of the current Lean module, falling back to the workspace root -/
+def getCurrentProjectContext (env : Environment) : IO ProjectContext := do
+  match env.getModulePackage? with
+  | some id => getProjectContextForPackage id
+  | none => getRootProjectContext

--- a/I18n/Template.lean
+++ b/I18n/Template.lean
@@ -28,6 +28,47 @@ open Lean System
 
 namespace I18n
 
+/-- Which imported translation keys should be written to a template -/
+inductive TemplateScope where
+  /-- Export only entries owned by the current Lake package -/
+  | packageOnly
+  /-- Export all entries visible through imports -/
+  | bundle
+deriving Inhabited, BEq, Repr
+
+/-- Records an explicit template scope so the CLI can reproduce embedded export behaviour -/
+meta initialize templateScopeExt : SimplePersistentEnvExtension TemplateScope (Option TemplateScope) ←
+  registerSimplePersistentEnvExtension {
+    name := `i18n_template_scope
+    asyncMode := .sync
+    addEntryFn := fun _ scope => some scope
+    addImportedFn := fun _ => none }
+
+private meta def mergeTemplateScope (current : Option TemplateScope) (next : TemplateScope) :
+    Option TemplateScope := match current, next with
+  | some .bundle, _ | _, .bundle => some .bundle
+  | _, .packageOnly => some .packageOnly
+
+/-- Return the explicit template mode recorded by modules in one package. -/
+meta def getTemplateScopeForPackage (env : Environment) (packageId : PkgId) :
+    Option TemplateScope := Id.run do
+  let mut scope := none
+
+  for moduleName in env.header.moduleNames do
+    if let some idx := env.getModuleIdx? moduleName then
+      if env.getModulePackageByIdx? idx == some packageId then
+        for entry in templateScopeExt.getModuleEntries env idx do
+          scope := mergeTemplateScope scope entry
+
+  let includeLocal := match env.getModulePackage? with
+    | some currentPackage => currentPackage == packageId
+    | none => true
+  if includeLocal then
+    for entry in templateScopeExt.getEntries env do
+      scope := mergeTemplateScope scope entry
+
+  return scope
+
 namespace POEntry
 
 /-- Merge two PO-entries. This will append refs and flags from the second entry to the first. -/
@@ -105,22 +146,20 @@ Write all collected untranslated strings into a template file.
 
 Note: returns the `FilePath` of the created file, simply to display a `logInfo` in `CommandElabM`.
 -/
-meta def createTemplateAux (keys : Array POEntry) : IO FilePath := do
-  let projectName ← getProjectName
-
+meta def createTemplateAuxFor (project : ProjectContext) (keys : Array POEntry) : IO FilePath := do
   -- read config instead of `languageState` because that state only
   -- gets initialised if `set_language` is used in the document.
-  let langConfig ← readLanguageConfig
+  let langConfig ← readLanguageConfigAt project.dir (createIfMissing := project.isRoot)
 
   let sourceLang := langConfig.sourceLang.toString
   let ending := if langConfig.useJson then "json" else "pot"
-  let fileName := s!"{projectName}.{ending}"
-  let path := (← IO.currentDir) / ".i18n" / sourceLang
+  let fileName := s!"{project.name}.{ending}"
+  let path := project.dir / ".i18n" / sourceLang
   IO.FS.createDirAll path
 
   let poFile : POFile := {
     header := {
-      projectIdVersion := s!"{projectName} v{Lean.versionString}"
+      projectIdVersion := s!"{project.name} v{Lean.versionString}"
       reportMsgidBugsTo := langConfig.translationContactEmail
       potCreationDate := (← Std.Time.PlainDate.now) |>.format "uuuu-MM-dd"
       language := sourceLang }
@@ -133,14 +172,23 @@ meta def createTemplateAux (keys : Array POEntry) : IO FilePath := do
 
   return (path / fileName)
 
-open Elab.Command in
+/-- Write a template for the root package. -/
+meta def createTemplateAux (keys : Array POEntry) : IO FilePath := do
+  createTemplateAuxFor (← getRootProjectContext) keys
 
-/--
-Write all collected untranslated strings into a template file.
--/
-meta def createTemplate : CommandElabM Unit := do
-  let keys := untranslatedKeysExt.getState (← getEnv)
-  let langConfig ← readLanguageConfig
+open Elab.Command
+
+private meta def createTemplateWithScope (scope : TemplateScope) : CommandElabM Unit := do
+  let env ← getEnv
+  let project ← getCurrentProjectContext env
+  modifyEnv (templateScopeExt.addEntry · scope)
+  unless project.isRoot do
+    return
+
+  let keys := match scope with
+    | .packageOnly => getUntranslatedKeysForPackage env project.id
+    | .bundle => untranslatedKeysExt.getState env
+  let langConfig ← readLanguageConfigAt project.dir
   let opts ← getOptions
   let sortByFile := langConfig.sortByFile || opts.getBool `i18n.sortByFile false
   let (sortedKeys, warnings) := prepareTemplateEntries keys sortByFile
@@ -148,9 +196,19 @@ meta def createTemplate : CommandElabM Unit := do
   for warning in warnings do
     logWarning warning.toMessageData
 
-  let path ← createTemplateAux sortedKeys
+  let path ← createTemplateAuxFor project sortedKeys
   logInfo s!"i18n: file created at {path}"
+
+/--
+Write all untranslated strings into one template file (so Lean4Game does not break).
+-/
+meta def createTemplate : CommandElabM Unit := do
+  createTemplateWithScope .bundle
+
+/-- For a package-owned catalog & write only the current packages untranslated strings -/
+meta def createPackageTemplate : CommandElabM Unit := do
+  createTemplateWithScope .packageOnly
 
 open Elab.Command in
 elab "#export_i18n" : command => do
-  createTemplate
+  createPackageTemplate

--- a/I18n/Translate.lean
+++ b/I18n/Translate.lean
@@ -26,11 +26,10 @@ namespace I18n
 /-- Load translations from PO-file. They can then be accessed with `I18n.getTranslations`. -/
 meta def loadTranslations : CoreM Unit := do
   let langState ← getLanguageState
-  let projectDir ← IO.currentDir
-  let projectName ← getProjectName
+  let project ← getCurrentProjectContext (← getEnv)
 
   let ending := if langState.useJson then "json" else "po"
-  let file := projectDir / ".i18n" / s!"{langState.lang}" / s!"{projectName.toString}.{ending}"
+  let file := project.dir / ".i18n" / s!"{langState.lang}" / s!"{project.name.toString}.{ending}"
   if ¬ (← FilePath.pathExists file) then
     logWarning s!"Translation file not found: {file}"
     return ()
@@ -47,8 +46,15 @@ meta def loadTranslations : CoreM Unit := do
 elab "set_language" lang:ident : command => do
   -- Load the language state
   let language : Language := Language.ofString lang.getId.toString
-  let langState ← readLanguageConfig language
+  let project ← getCurrentProjectContext (← getEnv)
+  let langState ← readLanguageConfigAt project.dir (some language) project.isRoot
   setLanguageState {langState with lang := language}
+
+  /-
+  Do not keep translations from an earlier `set_language` command in the same module when the new
+  catalog is partial or missing
+  -/
+  modifyEnv (translationExt.setState · {})
 
   -- Load in the translation for that language
   Elab.Command.liftCoreM <| loadTranslations

--- a/I18nCli/Cli.lean
+++ b/I18nCli/Cli.lean
@@ -4,7 +4,7 @@ public meta import Lean.Util.Path
 public meta import Cli.Basic
 public meta import I18n.PO
 public meta import I18nCli.Lean.Environment
-public import I18n.Template
+public meta import I18n.Template
 public meta import I18n.PO.Read
 
 namespace I18n
@@ -23,12 +23,16 @@ public meta unsafe def i18nCLI (args : Cli.Parsed) : IO UInt32 := do
     initSearchPath (← findSysroot)
     unsafe Lean.enableInitializersExecution
     try I18n.withImportModules #[module] {} (trustLevel := 1024) fun env => do
-      let keys := untranslatedKeysExt.getState env
-      let langConfig ← readLanguageConfig
+      let project ← getRootProjectContext
+      let scope := (getTemplateScopeForPackage env project.id).getD .packageOnly
+      let keys := match scope with
+        | .packageOnly => getUntranslatedKeysForPackage env project.id
+        | .bundle => untranslatedKeysExt.getState env
+      let langConfig ← readLanguageConfigAt project.dir
       let (sortedKeys, warnings) := prepareTemplateEntries keys langConfig.sortByFile
       for warning in warnings do
         IO.eprintln warning.toString
-      let path ← createTemplateAux sortedKeys
+      let path ← createTemplateAuxFor project sortedKeys
       IO.println s!"i18n: file created at {path}"
     catch err =>
       throw <| IO.userError <| s!"{err}\n" ++

--- a/README.md
+++ b/README.md
@@ -31,11 +31,21 @@ your project. To save them all to a template file, you have multiple options (ch
 * Call `lake exe i18n --template` inside your project (after `lake build`).
 * Place `#export_i18n` inside any Lean document. This will be executed every time that Lean
   document is built.
-* call `I18n.createTemplate` at any suitable point in your code.
+* call `I18n.createPackageTemplate` at any suitable point in your code.
 
 Any of these options will create a file `.i18n/en/[YourProject].pot` which you can
 translate using any a suitable editor like "Poedit" (these editors also help you merging a modified `.pot` into an existing translation).
 The translated files should be saved as `.i18n/[lang]/[YourProject].po`.
+
+### Dependent packages
+
+Translation catalogs are owned by Lake packages. Importing another translated package does not
+copy that dependency's strings into the current package's template, and translations with the same
+`msgid` in two packages do not overwrite each other. Each package keeps its own configuration and
+catalogs in its package-local `.i18n` directory.
+
+`lake exe i18n --template`, `#export_i18n`, and `I18n.createPackageTemplate` create a template for
+the current package only.
 
 Template entries are sorted by `msgid` by default. This keeps generated template files
 stable and silently merges duplicate `msgid`s. If you prefer entries in source-file order,


### PR DESCRIPTION
When i18n processes a source file, it now checks which Lake package owns that file. For an imported dependency, it finds the dependency’s directory through the Lake manifest and loads the translations from that dependency’s .i18n directory. The translations do not need to be copied into the main project.

For example, if App depends on Library, texts belonging to App are written to App.pot, while texts belonging to Library remain in Library.pot. When the application uses a translated text from Library, lean-i18n reads Library’s translation file. This also means both packages can use the same English text but translate it differently without overwriting each other. The template command now includes only texts owned by the current package by default.

I tested this with Robo. The generated .pot did not contain unrelated messages from Mathlib, i18n. Generating the .pot with lake exe i18n --template produced the same result.
